### PR TITLE
LTS-4004: bump form-data to 4.0.6 — fixes CRLF injection (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5122,16 +5122,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5144,6 +5145,19 @@
       "dev": true,
       "engines": {
         "node": ">= 14.17"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -14783,16 +14797,27 @@
       }
     },
     "form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "dependencies": {
+        "hasown": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+          "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.2"
+          }
+        }
       }
     },
     "form-data-encoder": {


### PR DESCRIPTION
## What

Bumps the transitive dev-dependency `form-data` to the patched release in the lockfile:

| Copy | Before | After |
|------|--------|-------|
| `node_modules/form-data` | 4.0.4 | **4.0.6** |

Adds nested `hasown@2.0.4` — the sole new sub-dependency of `form-data@4.0.6`. Every other 4.0.6 requirement (`asynckit`, `combined-stream`, `es-set-tostringtag`, `mime-types@2.1.35`) is already satisfied by the existing tree.

## Why

Resolves **[GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx)** — CRLF injection in `form-data` via unescaped multipart field names and filenames (CWE-93, CVSS 7.5). Patched in 4.0.6, which escapes `\r`, `\n`, and `"` per the WHATWG `multipart/form-data` algorithm.

Jira: **LTS-4004**

## Notes

- `form-data` is **not** a direct dependency — it's pulled in transitively by dev tooling. The patched version satisfies the existing semver range, so there is no `package.json` change.
- **`package-lock.json`-only** change, `+35 / −10`. No runtime or source changes.
- Supersedes **#14**, which was based on an older `main` and went conflicting after the LTS-3295 SDK bump rewrote the lockfile. This branch is rebased on current `main`, giving a minimal, conflict-free diff (no incidental `puppeteer-core` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
